### PR TITLE
readiness and liveness check endpoints plus grpc upgrade

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -240,6 +240,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:9f984428bac26e6472738ab372867bfa17b9d4ac5d3f10e9665f6d8692bead55"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  pruneopts = ""
+  revision = "3b58ed4ad3395d483fc92d5d14123ce2c3581fec"
+
+[[projects]]
+  branch = "master"
   digest = "1:e887950913f1ea214e95d4fc59bd2467ecf234466f63ab83a10ec874010c54f4"
   name = "golang.org/x/text"
   packages = [
@@ -286,35 +294,41 @@
   revision = "1e559d0a00eef8a9a43151db4665280bd8dd5886"
 
 [[projects]]
-  digest = "1:18f77768d38684d7ff8f4bdad082ce6e8b867ae538a5900e38bbc08db05372a2"
+  digest = "1:cb1330030248de97a11d9f9664f3944fce0df947e5ed94dbbd9cb6e77068bd46"
   name = "google.golang.org/grpc"
   packages = [
     ".",
     "balancer",
+    "balancer/base",
     "balancer/roundrobin",
     "codes",
     "connectivity",
     "credentials",
     "encoding",
-    "grpclb/grpc_lb_v1/messages",
+    "encoding/proto",
     "grpclog",
+    "health",
+    "health/grpc_health_v1",
     "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
     "peer",
     "resolver",
     "resolver/dns",
-    "resolver/manual",
     "resolver/passthrough",
     "stats",
     "status",
     "tap",
-    "transport",
   ]
   pruneopts = ""
-  revision = "be077907e29fdb945d351e4284eb5361e7f8924e"
-  version = "v1.8.1"
+  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
+  version = "v1.14.0"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -344,6 +358,8 @@
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/grpclog",
+    "google.golang.org/grpc/health",
+    "google.golang.org/grpc/health/grpc_health_v1",
     "google.golang.org/grpc/metadata",
     "google.golang.org/grpc/peer",
     "google.golang.org/grpc/status",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,4 +58,4 @@
 
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "^1.8.0"
+  version = "^1.14.0"

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ get:
 	dep ensure
 
 publish: build
+ifneq ($(skiplogin),true)
+	docker login
+endif
 	docker build \
 		--build-arg VCS_REF=${VCS_REF} \
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \

--- a/cmd/mnemosyned/main.go
+++ b/cmd/mnemosyned/main.go
@@ -38,6 +38,7 @@ func main() {
 	debugListener := initListener(l, config.host, config.port+1)
 
 	daemon, err := mnemosyned.NewDaemon(&mnemosyned.DaemonOpts{
+		Version:           version,
 		SessionTTL:        config.session.ttl,
 		SessionTTC:        config.session.ttc,
 		Storage:           config.storage,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,11 @@ services:
     container_name: mnemosyned-1
     image: piotrkowalczuk/mnemosyne:latest
     ports:
-      - 10010:8080
-      - 10011:8081
+      - 20010:8080
+      - 20011:8081
     environment:
-      MNEMOSYNED_MONITORING: "true"
+      MNEMOSYNED_LOG_ENVIRONMENT: development
+      MNEMOSYNED_LOG_LEVEL: debug
       MNEMOSYNED_CLUSTER_LISTEN: mnemosyned-1:8080
       MNEMOSYNED_CLUSTER_SEEDS: mnemosyned-2:8080,mnemosyned-3:8080
       MNEMOSYNED_POSTGRES_SCHEMA: mnemosyne1
@@ -29,10 +30,11 @@ services:
     container_name: mnemosyned-2
     image: piotrkowalczuk/mnemosyne:latest
     ports:
-      - 10020:8080
-      - 10021:8081
+      - 20020:8080
+      - 20021:8081
     environment:
-      MNEMOSYNED_MONITORING: "true"
+      MNEMOSYNED_LOG_ENVIRONMENT: development
+      MNEMOSYNED_LOG_LEVEL: debug
       MNEMOSYNED_CLUSTER_LISTEN: mnemosyned-2:8080
       MNEMOSYNED_CLUSTER_SEEDS: mnemosyned-1:8080,mnemosyned-3:8080
       MNEMOSYNED_POSTGRES_SCHEMA: mnemosyne2
@@ -46,10 +48,11 @@ services:
     container_name: mnemosyned-3
     image: piotrkowalczuk/mnemosyne:latest
     ports:
-      - 10030:8080
-      - 10031:8081
+      - 20030:8080
+      - 20031:8081
     environment:
-      MNEMOSYNED_MONITORING: "true"
+      MNEMOSYNED_LOG_ENVIRONMENT: development
+      MNEMOSYNED_LOG_LEVEL: debug
       MNEMOSYNED_CLUSTER_LISTEN: mnemosyned-3:8080
       MNEMOSYNED_CLUSTER_SEEDS: mnemosyned-1:8080,mnemosyned-2:8080
       MNEMOSYNED_POSTGRES_SCHEMA: mnemosyne3

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -1,6 +1,7 @@
 package cluster_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -148,7 +149,7 @@ func TestCluster_GetOther(t *testing.T) {
 	c, cancel := testCluster(t)
 	defer cancel()
 
-	if err := c.Connect(grpc.WithInsecure(), grpc.WithBlock()); err != nil {
+	if err := c.Connect(context.TODO(), grpc.WithInsecure(), grpc.WithBlock()); err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 
@@ -168,7 +169,7 @@ func TestCluster_GetOther(t *testing.T) {
 func TestCluster_Connect(t *testing.T) {
 	c, cancel := testCluster(t)
 	defer cancel()
-	if err := c.Connect(grpc.WithInsecure(), grpc.WithBlock()); err != nil {
+	if err := c.Connect(context.TODO(), grpc.WithInsecure(), grpc.WithBlock()); err != nil {
 		t.Fatalf("unexpected error: %s", err.Error())
 	}
 }

--- a/mnemosyned/daemon_test.go
+++ b/mnemosyned/daemon_test.go
@@ -6,12 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/piotrkowalczuk/mnemosyne/mnemosynerpc"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestDaemon_Run(t *testing.T) {
@@ -87,8 +87,8 @@ func TestDaemon_Run(t *testing.T) {
 			t.Errorf("%d: missing error", i)
 			return
 		}
-		if grpc.Code(err) != codes.NotFound {
-			t.Errorf("%d: wrong error code, expected %d but got %d", i, codes.NotFound, grpc.Code(err))
+		if status.Code(err) != codes.NotFound {
+			t.Errorf("%d: wrong error code, expected %d but got %d", i, codes.NotFound, status.Code(err))
 			return
 		}
 

--- a/mnemosyned/health.go
+++ b/mnemosyned/health.go
@@ -3,30 +3,120 @@ package mnemosyned
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"time"
 
+	"encoding/json"
+
+	"sync"
+
+	"github.com/piotrkowalczuk/mnemosyne/internal/cluster"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-type healthHandler struct {
-	logger   *zap.Logger
-	postgres *sql.DB
+type livenessResponse struct {
+	Version string `json:"version"`
 }
 
-func (hh *healthHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	if hh.postgres != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
+type livenessHandler struct {
+	livenessResponse
 
-		if err := hh.postgres.PingContext(ctx); err != nil {
-			hh.logger.Debug("health check failure due to postgres connection")
-			http.Error(rw, "postgres ping failure", http.StatusServiceUnavailable)
-			return
-		}
+	logger *zap.Logger
+}
+
+func (lh *livenessHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if err := json.NewEncoder(rw).Encode(lh.livenessResponse); err != nil {
+		http.Error(rw, fmt.Sprintf("liveness check response encode failure: %s", err.Error()), http.StatusInternalServerError)
+		return
 	}
 
-	hh.logger.Debug("successful health check")
+	lh.logger.Debug("liveness check done")
 	rw.WriteHeader(http.StatusOK)
-	rw.Write([]byte("1"))
+}
+
+type readinessResponse struct {
+	sync.Mutex `json:"-"`
+
+	livenessResponse
+
+	Probes struct {
+		Postgres probeStatus            `json:"postgres"`
+		Cluster  map[string]probeStatus `json:"cluster"`
+	} `json:"probes"`
+}
+
+type readinessHandler struct {
+	livenessResponse
+
+	logger   *zap.Logger
+	postgres *sql.DB
+	cluster  *cluster.Cluster
+}
+
+func (rh *readinessHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	var (
+		wg     sync.WaitGroup
+		status readinessResponse
+	)
+
+	status.livenessResponse = rh.livenessResponse
+	status.Probes.Cluster = make(map[string]probeStatus, rh.cluster.Len())
+
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		if rh.postgres != nil {
+			if err := rh.postgres.PingContext(ctx); err != nil {
+				status.Probes.Postgres = probeStatus(err.Error())
+			}
+		}
+	}()
+
+	for _, n := range rh.cluster.ExternalNodes() {
+		wg.Add(1)
+
+		go func(n *cluster.Node) {
+			defer wg.Done()
+
+			res, err := n.Health.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+
+			status.Lock()
+			defer status.Unlock()
+
+			if err != nil {
+				status.Probes.Cluster[n.Addr] = probeStatus(err.Error())
+			} else {
+				status.Probes.Cluster[n.Addr] = probeStatus(res.Status.String())
+			}
+		}(n)
+	}
+
+	wg.Wait()
+
+	if err := json.NewEncoder(rw).Encode(status); err != nil {
+		http.Error(rw, fmt.Sprintf("readiness check response encode failure: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	rh.logger.Debug("readiness check done", zap.Any("probes", status.Probes), zap.Int("nb_of_external_nodes", len(rh.cluster.ExternalNodes())))
+}
+
+type probeStatus string
+
+func (ps probeStatus) IsOK() bool {
+	return ps == ""
+}
+
+func (ps probeStatus) MarshalJSON() ([]byte, error) {
+	if ps.IsOK() {
+		return json.Marshal(grpc_health_v1.HealthCheckResponse_SERVING.String())
+	}
+
+	return json.Marshal(string(ps))
 }

--- a/mnemosyned/middleware.go
+++ b/mnemosyned/middleware.go
@@ -46,7 +46,7 @@ func errorInterceptor(log *zap.Logger) func(context.Context, interface{}, *grpc.
 
 			res, err := handler(ctx, req)
 
-			code := grpc.Code(err)
+			code := status.Code(err)
 			if err != nil && code != codes.OK {
 				if code == codes.Unknown {
 					switch err {
@@ -64,7 +64,7 @@ func errorInterceptor(log *zap.Logger) func(context.Context, interface{}, *grpc.
 					}
 				}
 				loggerBackground(ctx, log).Error("request failure",
-					zap.String("error", grpc.ErrorDesc(err)),
+					zap.String("error", status.Convert(err).Message()),
 					logger.Ctx(ctx, info, code),
 				)
 
@@ -76,7 +76,7 @@ func errorInterceptor(log *zap.Logger) func(context.Context, interface{}, *grpc.
 				case storage.ErrMissingAccessToken, storage.ErrMissingSession, storage.ErrMissingSubjectID:
 					return nil, status.Errorf(codes.InvalidArgument, "mnemosyned: %s", err.Error())
 				default:
-					return nil, grpc.Errorf(grpc.Code(err), "mnemosyned: %s", grpc.ErrorDesc(err))
+					return nil, status.Errorf(status.Code(err), "mnemosyned: %s", status.Convert(err).Message())
 				}
 			}
 

--- a/mnemosyned/session_manager.go
+++ b/mnemosyned/session_manager.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -108,11 +107,11 @@ func newSessionManager(opts sessionManagerOpts) (*sessionManager, error) {
 func (sm *sessionManager) Context(ctx context.Context, req *empty.Empty) (*mnemosynerpc.ContextResponse, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing metadata in context, access token cannot be retrieved")
+		return nil, status.Errorf(codes.InvalidArgument, "missing metadata in context, access token cannot be retrieved")
 	}
 
 	if len(md[mnemosyne.AccessTokenMetadataKey]) == 0 {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing access token in metadata")
+		return nil, status.Errorf(codes.InvalidArgument, "missing access token in metadata")
 	}
 
 	at := md[mnemosyne.AccessTokenMetadataKey][0]

--- a/mnemosyned/session_manager_delete.go
+++ b/mnemosyned/session_manager_delete.go
@@ -11,8 +11,8 @@ import (
 	"github.com/piotrkowalczuk/mnemosyne/mnemosynerpc"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type sessionManagerDelete struct {
@@ -24,7 +24,7 @@ type sessionManagerDelete struct {
 
 func (smd *sessionManagerDelete) Delete(ctx context.Context, req *mnemosynerpc.DeleteRequest) (*wrappers.Int64Value, error) {
 	if req.AccessToken == "" && req.RefreshToken == "" && req.ExpireAtFrom == nil && req.ExpireAtTo == nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "none of expected arguments was provided")
+		return nil, status.Errorf(codes.InvalidArgument, "none of expected arguments was provided")
 	}
 
 	var expireAtFrom, expireAtTo *time.Time

--- a/mnemosyned/session_manager_set_value.go
+++ b/mnemosyned/session_manager_set_value.go
@@ -7,8 +7,8 @@ import (
 	"github.com/piotrkowalczuk/mnemosyne/mnemosynerpc"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type sessionManagerSetValue struct {
@@ -23,7 +23,7 @@ func (smsv *sessionManagerSetValue) SetValue(ctx context.Context, req *mnemosyne
 	case req.AccessToken == "":
 		return nil, errMissingAccessToken
 	case req.Key == "":
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing bag key")
+		return nil, status.Errorf(codes.InvalidArgument, "missing bag key")
 	}
 
 	if node, ok := smsv.cluster.GetOther(req.AccessToken); ok {

--- a/mnemosyned/session_manager_start.go
+++ b/mnemosyned/session_manager_start.go
@@ -8,8 +8,8 @@ import (
 	"github.com/piotrkowalczuk/mnemosyne/mnemosynerpc"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type sessionManagerStart struct {
@@ -27,7 +27,7 @@ func (sms *sessionManagerStart) Start(ctx context.Context, req *mnemosynerpc.Sta
 		var err error
 		req.Session.AccessToken, err = mnemosyne.RandomAccessToken()
 		if err != nil {
-			return nil, grpc.Errorf(codes.Internal, "access token generation failure: %s", err.Error())
+			return nil, status.Errorf(codes.Internal, "access token generation failure: %s", err.Error())
 		}
 	}
 

--- a/mnemosyned/session_manager_test.go
+++ b/mnemosyned/session_manager_test.go
@@ -16,9 +16,9 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/mock"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 func TestSessionManager_mockedStore(t *testing.T) {
@@ -158,7 +158,7 @@ func TestSessionManager_Start_postgresStore(t *testing.T) {
 					resp, err := s.client.Start(context.Background(), &mnemosynerpc.StartRequest{})
 
 					So(resp, ShouldBeNil)
-					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, grpc.ErrorDesc(errMissingSession))
+					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, status.Convert(errMissingSession).Message())
 				})
 			})
 		}))
@@ -181,7 +181,7 @@ func TestSessionManager_Start_postgresStore(t *testing.T) {
 						resp, err := s[i].client.Start(context.Background(), &mnemosynerpc.StartRequest{})
 
 						So(resp, ShouldBeNil)
-						So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, grpc.ErrorDesc(errMissingSession))
+						So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, status.Convert(errMissingSession).Message())
 					}
 				})
 			})
@@ -222,7 +222,7 @@ func TestSessionManager_Get_postgresStore(t *testing.T) {
 						resp, err := s.client.Get(context.Background(), &mnemosynerpc.GetRequest{})
 
 						So(resp, ShouldBeNil)
-						So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, grpc.ErrorDesc(errMissingAccessToken))
+						So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, status.Convert(errMissingAccessToken).Message())
 					})
 				})
 			})
@@ -407,7 +407,7 @@ func TestSessionManager_Exists_postgresStore(t *testing.T) {
 					res, err := s.client.Exists(context.Background(), &mnemosynerpc.ExistsRequest{})
 
 					So(res, ShouldBeNil)
-					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, grpc.ErrorDesc(errMissingAccessToken))
+					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, status.Convert(errMissingAccessToken).Message())
 				})
 			})
 		})
@@ -455,7 +455,7 @@ func TestSessionManager_Abandon_postgresStore(t *testing.T) {
 					resp, err := s.client.Abandon(context.Background(), &mnemosynerpc.AbandonRequest{})
 
 					So(resp, ShouldBeNil)
-					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, grpc.ErrorDesc(errMissingAccessToken))
+					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, status.Convert(errMissingAccessToken).Message())
 				})
 			})
 		})
@@ -590,7 +590,7 @@ func TestSessionManager_SetValue_postgresStore(t *testing.T) {
 					})
 
 					So(resp, ShouldBeNil)
-					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, grpc.ErrorDesc(errMissingAccessToken))
+					So(err, ShouldBeGRPCError(ShouldEqual), codes.InvalidArgument, status.Convert(errMissingAccessToken).Message())
 				})
 			})
 		})

--- a/mnemosyned/suite_e2e_test.go
+++ b/mnemosyned/suite_e2e_test.go
@@ -8,6 +8,8 @@ import (
 
 	"go.uber.org/zap"
 
+	"context"
+
 	"github.com/piotrkowalczuk/mnemosyne/internal/storage"
 	"github.com/piotrkowalczuk/mnemosyne/mnemosynerpc"
 	. "github.com/smartystreets/goconvey/convey"
@@ -83,11 +85,14 @@ func (es *e2eSuite) setup(t *testing.T, i int) {
 		t.Log("test daemon started")
 	}
 
-	es.clientConn, err = grpc.Dial(
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	es.clientConn, err = grpc.DialContext(
+		ctx,
 		es.listener.Addr().String(),
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
-		grpc.WithTimeout(2*time.Second),
 	)
 	if err != nil {
 		t.Fatalf("unexpected client conn error: %s", err.Error())

--- a/mnemosyned/suite_integration_test.go
+++ b/mnemosyned/suite_integration_test.go
@@ -7,6 +7,8 @@ import (
 
 	"go.uber.org/zap"
 
+	"context"
+
 	"github.com/piotrkowalczuk/mnemosyne/internal/cluster"
 	"github.com/piotrkowalczuk/mnemosyne/internal/storage"
 	"github.com/piotrkowalczuk/mnemosyne/internal/storage/storagemock"
@@ -47,11 +49,15 @@ func (is *integrationSuite) setup(t *testing.T) {
 	mnemosynerpc.RegisterSessionManagerServer(is.server, is.serviceServer)
 
 	go is.server.Serve(is.listener)
-	is.serviceConn, err = grpc.Dial(
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	is.serviceConn, err = grpc.DialContext(
+		ctx,
 		is.listener.Addr().String(),
 		grpc.WithInsecure(),
 		grpc.WithBlock(),
-		grpc.WithTimeout(2*time.Second),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/mnemosyned/suite_test.go
+++ b/mnemosyned/suite_test.go
@@ -10,7 +10,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/piotrkowalczuk/mnemosyne/mnemosynerpc"
 	"github.com/smartystreets/goconvey/convey"
-	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -111,10 +111,10 @@ func ShouldBeGRPCError(compare func(interface{}, ...interface{}) string) func(ac
 		if !ok {
 			return "The given value must implement error interface."
 		}
-		if s = compare(grpc.ErrorDesc(e), expected[1]); s != "" {
+		if s = compare(status.Convert(e).Message(), expected[1]); s != "" {
 			return
 		}
-		if s = convey.ShouldEqual(grpc.Code(e), expected[0]); s != "" {
+		if s = convey.ShouldEqual(status.Code(e), expected[0]); s != "" {
 			return
 		}
 		return

--- a/scripts/docker-healthcheck.sh
+++ b/scripts/docker-healthcheck.sh
@@ -2,4 +2,4 @@
 set -e
 
 : ${MNEMOSYNED_PORT:=8080}
-curl -f http://localhost:$((MNEMOSYNED_PORT+1))/health || exit 1
+curl -f http://localhost:$((MNEMOSYNED_PORT+1))/healthr || exit 1


### PR DESCRIPTION
This PR introduces:
* gRPC package upgrade to `^v1.14.0`
* New (for internal use) gRPC health check service using `grpc_health_v1.RegisterHealthServer`
* New postgres storage metric `mnemosyned_storage_postgres_query_duration_seconds`
* Two new health check endpoints `/healthz` (liveness) and `/healthr` (readiness) instead of single `/health`.

```json
{
  "version": "v0.16.0-dirty",
  "probes": {
    "postgres": "SERVING",
    "cluster": {
      "mnemosyned-2:8080": "SERVING",
      "mnemosyned-3:8080": "SERVING"
    } 
  }
}
```