### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/storage/postgres/storage.go
+++ b/internal/storage/postgres/storage.go
@@ -174,7 +174,7 @@ func (s *Storage) Get(ctx context.Context, accessToken string) (*mnemosynerpc.Se
 	}, nil
 }
 
-// sessionManagerList implements storage interface.
+// List implements storage interface.
 func (s *Storage) List(ctx context.Context, offset, limit int64, expiredAtFrom, expiredAtTo *time.Time) ([]*mnemosynerpc.Session, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "postgres.storage.list")
 	defer span.Finish()

--- a/mnemosyned/session_manager.go
+++ b/mnemosyned/session_manager.go
@@ -119,7 +119,7 @@ func newSessionManager(opts sessionManagerOpts) (*sessionManager, error) {
 	}, nil
 }
 
-// Get implements RPCServer interface.
+// Context gets implements RPCServer interface.
 func (sm *sessionManager) Context(ctx context.Context, req *empty.Empty) (*mnemosynerpc.ContextResponse, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?